### PR TITLE
lib.rs: remove html_root_url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 //! Rust FFI bindings to the [FTDI D2XX drivers](https://www.ftdichip.com/Drivers/D2XX.htm).
-#![doc(html_root_url = "https://docs.rs/libftd2xx-ffi/0.8.4")]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -4,8 +4,3 @@
 fn test_readme_deps() {
     version_sync::assert_markdown_deps_updated!("README.md");
 }
-
-#[test]
-fn test_html_root_url() {
-    version_sync::assert_html_root_url_updated!("src/lib.rs");
-}


### PR DESCRIPTION
This is no longer recommended by the API guidelines.