### PR TITLE
Don't run clippy on bindgen files. Added all the lints for `build.rs`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,14 @@ exclude = [
     "vendor/linux/**/libusb",
 ]
 
+[lints.rust]
+rust_2018_idioms = { level = "warn", priority = -1 }
+future-incompatible = "warn"
+
+[lints.clippy]
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+
 [dependencies]
 cfg-if = "^1.0.0"
 

--- a/build.rs
+++ b/build.rs
@@ -74,13 +74,13 @@ fn header_path() -> PathBuf {
                 "x86" => path.push("x86"),
                 "arm" | "aarch64" => match env::var("TARGET").unwrap().as_str() {
                     "arm-unknown-linux-musleabihf" | "arm-unknown-linux-gnueabihf" => {
-                        path.push("armv6-hf")
+                        path.push("armv6-hf");
                     }
                     "armv7-unknown-linux-musleabihf" | "armv7-unknown-linux-gnueabihf" => {
-                        path.push("armv7-hf")
+                        path.push("armv7-hf");
                     }
                     "aarch64-unknown-linux-musl" | "aarch64-unknown-linux-gnu" => {
-                        path.push("armv8-hf")
+                        path.push("armv8-hf");
                     }
                     target => panic!("Target not supported: {target}"),
                 },
@@ -131,8 +131,7 @@ fn linker_options() {
     println!("cargo:rustc-link-lib=static=ftd2xx");
 
     match env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() {
-        "windows" => {}
-        "linux" => {}
+        "windows" | "linux" => {}
         "macos" => {
             println!("cargo:rustc-link-lib=framework=IOKit");
             println!("cargo:rustc-link-lib=framework=CoreFoundation");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,6 @@
 //! Rust FFI bindings to the [FTDI D2XX drivers](https://www.ftdichip.com/Drivers/D2XX.htm).
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::upper_case_acronyms)]
-#![allow(clippy::useless_transmute)]
+#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
+#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "bindgen")] {


### PR DESCRIPTION
This should help https://github.com/ftdi-rs/libftd2xx-ffi/pull/76

This is just allowing all clippy lints of generated code, as there's no point in linting bindgen. There's not much code in build.rs, so I just added all the lints and did the appropriate fixes.

You can see it properly failing here
https://github.com/Grinkers/libftd2xx-ffi-rs/commit/fe8ef335977e32bc1a0bdbcf86a57f7a3776d16e

Passing with the newest bindgen
https://github.com/Grinkers/libftd2xx-ffi-rs/commit/5eab0298b2bc987918f0c96d288b954ea439a5e6