### PR TITLE
CI: remove cron trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,13 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: "31 3 * * *"
 
 name: CI
 
 jobs:
-
   linux_build:
     name: Linux Build
     runs-on: ubuntu-22.04


### PR DESCRIPTION
I think this will prevent GitHub from disabling CI after 60 days of inactivity on the repository.